### PR TITLE
Remove redundant forward slash when constructing URLs from paths

### DIFF
--- a/src/fusionAuth.ts
+++ b/src/fusionAuth.ts
@@ -1,12 +1,13 @@
 import type {FusionAuth, FusionAuthConfig, UserInfo} from "./types";
-import {doRedirectForPath, getExpTime, getURLForPath} from "./utils";
+import {doRedirectForPath, getExpTime, getFormattedPath, getURLForPath} from "./utils";
+
 
 const DEFAULT_ACCESS_TOKEN_EXPIRE_WINDOW = 30000;
 
 export const createFusionAuth = (config: FusionAuthConfig): FusionAuth => {
 
   async function getUserInfo(): Promise<UserInfo> {
-    const path = config.mePath ?? '/app/me';
+    const path = getFormattedPath(config.mePath, '/app/me');
     const uri = getURLForPath(config, path);
     let resp = await fetch(uri, {
       credentials: 'include',
@@ -19,12 +20,12 @@ export const createFusionAuth = (config: FusionAuthConfig): FusionAuth => {
   }
 
   function login(state?: string): void {
-    const path = config.loginPath ?? '/app/login';
+    const path = getFormattedPath(config.loginPath, '/app/login');
     doRedirectForPath(config, path, {state});
   }
 
   function logout(): void {
-    const path = config.logoutPath ?? '/app/logout';
+    const path = getFormattedPath(config.logoutPath, '/app/logout');
     doRedirectForPath(config, path);
   }
 
@@ -33,7 +34,8 @@ export const createFusionAuth = (config: FusionAuthConfig): FusionAuth => {
     const expiresAt = getExpTime();
     if (!expiresAt || expiresAt > Date.now() + timeWindow) return;
 
-    const path = `${config.tokenRefreshPath ?? '/app/refresh'}/${config.clientId}`;
+    const tokenRefreshPath = getFormattedPath(config.tokenRefreshPath, '/app/refresh');
+    const path = `${tokenRefreshPath}/${config.clientId}`;
     const uri = getURLForPath(config, path);
     const resp = await fetch(uri, {
       method: 'POST',

--- a/src/utils/getFormattedPath.ts
+++ b/src/utils/getFormattedPath.ts
@@ -1,0 +1,26 @@
+/**
+ * Takes in a string which may or may not
+ * have a leading `/` and returns the same
+ * string but definitely with a leading `/`
+ */
+const getWithLeadingSlash = (someString: string) => {
+  return someString.startsWith('/') ? someString : `/${someString}`
+}
+
+/**
+ * Formats a potential `path` utilizing a fallback when no
+ * `path` is passed in. Ensures that `path` has a leading `/`.
+ * 
+ * #### Example
+ * ```ts
+ * getFormattedPath(undefined, "some/fallback") // "/some/fallback"
+ * getFormattedPath(undefined, "/some/fallback") // "/some/fallback"
+ * 
+ * getFormattedPath("some/path", "/some/fallback") // "/some/path"
+ * getFormattedPath("/some/path", "/some/fallback") // "/some/path"
+ * ```
+ */
+export const getFormattedPath = (path: string | undefined, fallbackPath: string) => {
+   return getWithLeadingSlash(path || fallbackPath)
+}
+ 

--- a/src/utils/getURLForPath.ts
+++ b/src/utils/getURLForPath.ts
@@ -3,7 +3,7 @@ import querystring from "query-string";
 
 export const getURLForPath = (config: FusionAuthConfig, path: string, params: Record<string, any> = {}): string => {
   return querystring.stringifyUrl({
-    url: config.serverUrl + "/" + path,
+    url: config.serverUrl + path,
     query: params
   });
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./getExpTime";
+export * from "./getFormattedPath";
 export * from "./getURLForPath";
 export * from "./doRedirectForPath";


### PR DESCRIPTION
## What is this PR and why do we need it?

[View issue](https://github.com/FusionAuth/fusionauth-vue-sdk/issues/3) for explanation.

This PR addresses the issue by 

1) removing the added `/` when creating a URL from a `path`
2) creating functionality that allows users to pass in paths with or without a leading `/`

This means that this PR should have no breaking changes.

## Testing

There is no test suite in the Vue SDK.

Because of this, we need to comb through the usages of `getURLForPath` to confirm that the removal of the extra `/` is warranted in all usages.

The built package can also be used in the [Vue Quickstart app](https://github.com/fusionauth/fusionauth-quickstart-javascript-vue-web) for further testing. 