### PR TITLE
Update 'publish' GitHub Action to use .nvmrc file for Node version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Use Node.js 20
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm publish


### PR DESCRIPTION
## What is this PR and why do we need it?

Currently, the `publish` GitHub action just uses a hardcoded value for which Node version to use when building for production release. This PR updates the action to utilize the project's `.nvmrc` file so it stays up-to-date with what developers use when developing the SDK.

#### Pre-Merge Checklist (if applicable)

NA
