### PR TITLE
declare .vue modules for typescript

### DIFF
--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare module '*.vue';


### PR DESCRIPTION
## What is this PR and why do we need it?
This is for issue #11 -- so typescript recognizes `.vue` files as modules.

#### Pre-Merge Checklist (if applicable)
-   [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.
