### PR TITLE
Adding archival note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+**This repo is out of date and is archived. `@fusionauth/vue-sdk` is currently maintained at https://github.com/FusionAuth/fusionauth-javascript-sdk/tree/main/packages/sdk-vue.**
+
 An SDK for using FusionAuth in Vue applications.
 
 # Table of Contents

--- a/generated/README.adoc
+++ b/generated/README.adoc
@@ -1,3 +1,5 @@
+*This repo is out of date and is archived. `@fusionauth/vue-sdk` is currently maintained at https://github.com/FusionAuth/fusionauth-javascript-sdk/tree/main/packages/sdk-vue.*
+
 An SDK for using FusionAuth in Vue applications.
 
 == Table of Contents


### PR DESCRIPTION
## What is this PR and why do we need it?
#20 - Adding an archival note to the README. Once this PR is merged, this repo is ready to become archived, and we will be maintaining `@fusionauth/vue-sdk` from the [vue-sdk package within our monorepo](https://github.com/FusionAuth/fusionauth-javascript-sdk/tree/main/packages/sdk-vue) going forward.

#### Pre-Merge Checklist (if applicable)
-   [x] Unit and Feature tests have been added/updated for logic changes, or there is a justifiable reason for not doing so.